### PR TITLE
feat: add shared plant input interface

### DIFF
--- a/PlantGridViz/client/index.ts
+++ b/PlantGridViz/client/index.ts
@@ -1,0 +1,11 @@
+import { PlantInput } from '../shared/schema';
+
+export const examplePlant: PlantInput = {
+  scientific_name: 'Pinus densiflora',
+  kr_name: '\uc18c\ub098\ubb34',
+  life_form: 'tree',
+  max_height_m: 35,
+  root_depth_cm_range: [30, 100],
+  light_requirement_1_5: 4,
+  lifespan_yr: 100,
+};

--- a/PlantGridViz/server/index.ts
+++ b/PlantGridViz/server/index.ts
@@ -1,0 +1,6 @@
+import { PlantInput } from '../shared/schema';
+
+export function savePlant(input: PlantInput): PlantInput {
+  // placeholder for server-side processing
+  return input;
+}

--- a/PlantGridViz/shared/schema.ts
+++ b/PlantGridViz/shared/schema.ts
@@ -1,0 +1,9 @@
+export interface PlantInput {
+  scientific_name: string;
+  kr_name: string;
+  life_form: string;
+  max_height_m: number;
+  root_depth_cm_range: [number, number];
+  light_requirement_1_5: number;
+  lifespan_yr: number;
+}


### PR DESCRIPTION
## Summary
- define `PlantInput` interface in shared schema
- use shared `PlantInput` in both client and server modules

## Testing
- `npx tsc --noEmit PlantGridViz/client/index.ts PlantGridViz/server/index.ts PlantGridViz/shared/schema.ts`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688da440fb00832aa4b9393d2d11340e