### PR TITLE
feat: convert selected plants to csv

### DIFF
--- a/PlantGridViz/server/layout.ts
+++ b/PlantGridViz/server/layout.ts
@@ -1,0 +1,22 @@
+import path from 'path';
+import { spawn } from 'child_process';
+import { PlantInput, selectedPlantsToCsv } from './utils/serialize';
+
+/**
+ * Run the Python layout generator after converting selected plants to CSV.
+ */
+export function runLayout(plants: PlantInput[], width: number, height: number, cell = 0.5): Promise<void> {
+  const csvPath = selectedPlantsToCsv(plants);
+  const script = path.resolve(__dirname, '../../plant_layout/main.py');
+  return new Promise((resolve, reject) => {
+    const args = [script, csvPath, width.toString(), height.toString(), '--cell', cell.toString()];
+    const proc = spawn('python', args, { stdio: 'inherit' });
+    proc.on('close', code => {
+      if (code === 0) {
+        resolve();
+      } else {
+        reject(new Error(`Layout process exited with code ${code}`));
+      }
+    });
+  });
+}

--- a/PlantGridViz/server/utils/serialize.ts
+++ b/PlantGridViz/server/utils/serialize.ts
@@ -1,0 +1,33 @@
+import fs from 'fs';
+import { tmpdir } from 'os';
+import path from 'path';
+
+export interface PlantInput {
+  [key: string]: string | number | boolean | null | undefined;
+}
+
+function escapeCsvValue(value: unknown): string {
+  if (value === null || value === undefined) return '';
+  const str = String(value);
+  if (/[",\n]/.test(str)) {
+    return '"' + str.replace(/"/g, '""') + '"';
+  }
+  return str;
+}
+
+/**
+ * Convert selected plants list to a CSV file.
+ * Returns path to temporary file written in UTF-8 encoding.
+ */
+export function selectedPlantsToCsv(plants: PlantInput[]): string {
+  const filePath = path.join(tmpdir(), `selected-plants-${Date.now()}.csv`);
+  if (plants.length === 0) {
+    fs.writeFileSync(filePath, '', { encoding: 'utf8' });
+    return filePath;
+  }
+  const headers = Object.keys(plants[0]);
+  const rows = plants.map(p => headers.map(h => escapeCsvValue(p[h])).join(','));
+  const csv = [headers.join(','), ...rows].join('\n');
+  fs.writeFileSync(filePath, csv, { encoding: 'utf8' });
+  return filePath;
+}


### PR DESCRIPTION
## Summary
- add `selectedPlantsToCsv` utility to export selected plants as UTF-8 CSV
- create `runLayout` which uses `selectedPlantsToCsv` before launching Python layout

## Testing
- `npx ts-node --compiler-options '{"module":"CommonJS"}' -e "const { selectedPlantsToCsv } = require('./PlantGridViz/server/utils/serialize'); const fp = selectedPlantsToCsv([{foo:1,bar:'baz'},{foo:2,bar:'qux'}]); console.log('path:', fp); console.log('content:', require('fs').readFileSync(fp,'utf8'));"`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688da44676a0832a9c8270f7dfc75683