### PR TITLE
Add JSON plant loading and CLI flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,13 @@ positions to estimate per-cell light levels.
 
    A sample dataset is provided in `sample_plants.csv`.
 
-3. Run the generator:
+3. Run the generator with a CSV file:
    ```bash
-   python -m plant_layout.main plants.csv WIDTH HEIGHT --cell 0.5 --out output
+   python -m plant_layout.main WIDTH HEIGHT plants.csv --cell 0.5 --out output
+   ```
+   To supply plant data directly as JSON:
+   ```bash
+   python -m plant_layout.main WIDTH HEIGHT --json '[{"scientific_name": "Quercus", "kr_name": "참나무"}]' --cell 0.5 --out output
    ```
    The script will produce `placement.json` and `layout.png` in the output folder.
 


### PR DESCRIPTION
## Summary
- add `load_plants_json` for loading plant data from a JSON object
- extend CLI with `--json` flag to accept plant data via JSON string
- document JSON usage in README

## Testing
- `python -m py_compile plant_layout/data.py plant_layout/main.py`
- `pytest`
- `python -m plant_layout.main 1 1 plants.csv --out out_csv`
- `python -m plant_layout.main 1 1 --json '[{"scientific_name":"Test","kr_name":"테스트","life_form":"","max_height_m":1,"root_depth_cm_range":"10-20","light_requirement_1_5":3,"lifespan_yr":5}]' --out out_json`


------
https://chatgpt.com/codex/tasks/task_e_688da4439a90832aa0fd8a2044a113a8