### PR TITLE
feat: allow configuring python interpreter

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,16 @@ positions to estimate per-cell light levels.
    ```
    The script will produce `placement.json` and `layout.png` in the output folder.
 
+## Environment Variables
+
+The server uses the `PYTHON` environment variable to determine which Python
+interpreter to run. Set it to the path of your preferred Python executable. If
+unset, it defaults to `python3`.
+
+```bash
+export PYTHON=/usr/bin/python3.11
+```
+
 ## License
 
 MIT

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -1,0 +1,18 @@
+import { Router } from 'express';
+import { spawn } from 'child_process';
+
+const router = Router();
+
+const PYTHON = process.env.PYTHON || 'python3';
+
+router.get('/python-version', (_req, res) => {
+  const proc = spawn(PYTHON, ['--version']);
+  let output = '';
+  proc.stdout.on('data', data => (output += data));
+  proc.stderr.on('data', data => (output += data));
+  proc.on('close', code => {
+    res.json({ version: output.trim(), code });
+  });
+});
+
+export default router;


### PR DESCRIPTION
## Summary
- allow server routes to select Python interpreter via `PYTHON` env var
- document `PYTHON` env var in README

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688dccec2108832aa4d08f5f3a11bf79