### PR TITLE
Add in-memory layout service function

### DIFF
--- a/plant_layout/__init__.py
+++ b/plant_layout/__init__.py
@@ -1,0 +1,3 @@
+from .service import run_layout
+
+__all__ = ["run_layout"]

--- a/plant_layout/service.py
+++ b/plant_layout/service.py
@@ -1,0 +1,20 @@
+from typing import List, Dict, Any
+from io import BytesIO
+
+from .data import load_plants_json
+from .grid import Grid
+from .layout import PlantLayout
+from .sunlight import default_sun_positions
+from .visualize import plot_layout
+
+
+def run_layout(plants: List[Dict[str, Any]], width: float, height: float, cell: float = 0.5) -> List[Dict[str, Any]]:
+    plant_objs = load_plants_json(plants)
+    sun_positions = default_sun_positions()
+    grid = Grid(width, height, cell)
+    grid.initialize_exposures(len(sun_positions))
+    layout = PlantLayout(grid, sun_positions)
+    layout.place_plants(plant_objs)
+    buffer = BytesIO()
+    plot_layout(layout, buffer)
+    return layout.to_dict()


### PR DESCRIPTION
## Summary
- expose a `run_layout` helper for generating plant placements without saving files

## Testing
- `python -m py_compile plant_layout/service.py plant_layout/__init__.py`
- `python - <<'PYTHON' 2>/dev/null
from plant_layout import run_layout
plants=[{"scientific_name":"A","kr_name":"A","life_form":"","max_height_m":1,"root_depth_cm_range":"10-20","light_requirement_1_5":3,"lifespan_yr":1}]
placements=run_layout(plants, 5, 5)
print(placements)
PYTHON`


------
https://chatgpt.com/codex/tasks/task_e_688f222f6674832aa66ce1b944e97c60