### PR TITLE
chore: add pyproject for editable install

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,17 @@
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "vla"
+version = "0.1.0"
+dependencies = [
+    "pandas",
+    "numpy",
+    "matplotlib",
+    "shapely"
+]
+
+
+[tool.setuptools.packages.find]
+include = ["plant_layout"]


### PR DESCRIPTION
## Summary
- add `pyproject.toml` so the repository can be installed in editable mode
- restrict packaging to the `plant_layout` module

## Testing
- `pip install -e .`
- `python -m plant_layout.main 10 10 plants.csv --out test_output`


------
https://chatgpt.com/codex/tasks/task_e_688b8289aeb8832abfdd5cd333c34ad8