### PR TITLE
Add helper script for PyInstaller binary

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,9 +27,23 @@ positions to estimate per-cell light levels.
    ```
    To supply plant data directly as JSON:
    ```bash
-   python -m plant_layout.main WIDTH HEIGHT --json '[{"scientific_name": "Quercus", "kr_name": "참나무"}]' --cell 0.5 --out output
-   ```
-   The script will produce `placement.json` and `layout.png` in the output folder.
+    python -m plant_layout.main WIDTH HEIGHT --json '[{"scientific_name": "Quercus", "kr_name": "참나무"}]' --cell 0.5 --out output
+    ```
+    The script will produce `placement.json` and `layout.png` in the output folder.
+
+### Building a Binary
+
+You can bundle `test.py` into a standalone executable manually with:
+
+```bash
+pyinstaller --onefile test.py
+```
+
+Alternatively, use the helper script:
+
+```bash
+./scripts/build_binary.sh
+```
 
 ## Environment Variables
 

--- a/scripts/build_binary.sh
+++ b/scripts/build_binary.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+pyinstaller --onefile test.py


### PR DESCRIPTION
## Summary
- add `scripts/build_binary.sh` to build a standalone `test.py` binary with PyInstaller
- document manual PyInstaller usage and helper script in README

## Testing
- `bash scripts/build_binary.sh`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68903ddcb550832ab04cd5d9398f1b0d