### PR TITLE
feat: cache shadow paths by height

### DIFF
--- a/plant_layout/layout.py
+++ b/plant_layout/layout.py
@@ -3,7 +3,7 @@ from typing import List, Tuple
 
 from .data import Plant, load_plants
 from .grid import Grid
-from .sunlight import SunPosition, default_sun_positions
+from .sunlight import SunPosition, default_sun_positions, sun_vector
 from .shadow import shadow_cells
 
 
@@ -11,12 +11,13 @@ class PlantLayout:
     def __init__(self, grid: Grid, sun_positions: List[SunPosition]):
         self.grid = grid
         self.sun_positions = sun_positions
+        # Precompute sun vectors for shadow calculations
+        self.sun_vectors = [sun_vector(s) for s in sun_positions]
         self.placements: List[Tuple[Plant, float, float]] = []
 
     def update_shadow(self, x: float, y: float, height: float):
-        for sun in self.sun_positions:
-            cells = shadow_cells(self.grid, x, y, height, sun)
-            self.grid.mark_shadow(cells)
+        cells = shadow_cells(self.grid, x, y, height, self.sun_vectors)
+        self.grid.mark_shadow(cells)
 
     def can_place(self, plant: Plant, row: int, col: int) -> bool:
         if self.grid.occupied[row, col]:

--- a/plant_layout/shadow.py
+++ b/plant_layout/shadow.py
@@ -1,22 +1,61 @@
-from typing import List, Tuple
+from typing import Dict, List, Tuple
 import math
 
 from .grid import Grid
-from .sunlight import SunPosition, sun_vector
 
 
-def shadow_cells(grid: Grid, x: float, y: float, height: float, sun: SunPosition) -> List[Tuple[int, int]]:
-    dx, dy, dz = sun_vector(sun)
-    if dz <= 0:
-        return []
-    length = height / dz
+# Cache for precomputed shadow paths based on plant height.
+_shadow_cache: Dict[float, List[List[Tuple[int, int]]]] = {}
+
+
+def compute_shadow_paths(
+    grid: Grid, height: float, sun_vectors: List[Tuple[float, float, float]]
+) -> List[List[Tuple[int, int]]]:
+    """Return relative cell paths for each sun vector.
+
+    Paths are cached by ``height`` so that multiple plants with the same height
+    reuse the computed cell offsets.
+    """
+
+    if height in _shadow_cache:
+        return _shadow_cache[height]
+
     step = grid.cell_size / 2
-    cells = []
-    dist = step
-    while dist <= length:
-        px = x + dx * dist
-        py = y + dy * dist
-        r, c = grid.cell_indices(px, py)
-        cells.append((r, c))
-        dist += step
+    paths: List[List[Tuple[int, int]]] = []
+    for dx, dy, dz in sun_vectors:
+        if dz <= 0:
+            paths.append([])
+            continue
+
+        length = height / dz
+        dist = step
+        cells: List[Tuple[int, int]] = []
+        while dist <= length:
+            dr = math.floor(0.5 + (dy * dist) / grid.cell_size)
+            dc = math.floor(0.5 + (dx * dist) / grid.cell_size)
+            cells.append((dr, dc))
+            dist += step
+        paths.append(cells)
+
+    _shadow_cache[height] = paths
+    return paths
+
+
+def shadow_cells(
+    grid: Grid,
+    x: float,
+    y: float,
+    height: float,
+    sun_vectors: List[Tuple[float, float, float]],
+) -> List[Tuple[int, int]]:
+    """Return cells shadowed by a plant at ``x, y`` with ``height``.
+
+    Precomputed paths for the given ``height`` are reused for efficiency.
+    """
+
+    paths = compute_shadow_paths(grid, height, sun_vectors)
+    base_row, base_col = grid.cell_indices(x, y)
+    cells: List[Tuple[int, int]] = []
+    for path in paths:
+        cells.extend((base_row + r, base_col + c) for r, c in path)
     return cells


### PR DESCRIPTION
## Summary
- cache shadow paths for each plant height and reuse them per sun vector
- precompute sun vectors in layout to apply cached shadows efficiently

## Testing
- `python -m plant_layout.main 1 1 plants.csv --out /tmp/out 2>&1 | tail -n 20`


------
https://chatgpt.com/codex/tasks/task_e_68906be2a570832ab6a60e620c0a6f9c